### PR TITLE
Improvements to reward logic, QoL on durability and added skill check

### DIFF
--- a/client/client.lua
+++ b/client/client.lua
@@ -14,7 +14,7 @@ AddEventHandler('mms-goldpfanne:client:startgoldpfanne',function()
                 active = true
                 TriggerServerEvent('mms-goldpfanne:server:ToolUsage')
                 Goldpan()
-            end        
+            end
         end
     end
 end)
@@ -32,7 +32,7 @@ function Goldpan()
     Citizen.Wait(Config.GoldPanTime - 5000)
     ClearPedTasks(playerPed)
     DeleteObject(goldpan)
-    Reward()
+    TriggerServerEvent('mms-goldpfanne:server:addreward')
     active = false
 end
 
@@ -48,6 +48,7 @@ function CrouchAnim()
     local coords = GetEntityCoords(ped)
     TaskPlayAnim(ped, dict, "inspectfloor_player", 0.5, 8.0, -1, 1, 0, false, false, false)
 end
+
 function GoldShake()
     local dict = "script_re@gold_panner@gold_success"
     RequestAnimDict(dict)
@@ -55,13 +56,4 @@ function GoldShake()
         Wait(10)
     end
     TaskPlayAnim(PlayerPedId(), dict, "SEARCH02", 1.0, 8.0, -1, 1, 0, false, false, false)
-end
-
-function Reward()
-    local reward = math.random(1,100)
-    if reward <= Config.RewardChance then
-        TriggerServerEvent('mms-goldpfanne:server:addreward')
-    else
-        VORPcore.NotifyTip(_U('NothingFound') , 5000)
-    end
 end

--- a/client/client.lua
+++ b/client/client.lua
@@ -30,11 +30,24 @@ function Goldpan()
     Citizen.Wait(5000)
     GoldShake()
     Citizen.Wait(Config.GoldPanTime - 5000)
+    local success = not Config.DoSkillCheck or DoSkillCheck()
     ClearPedTasks(playerPed)
     DeleteObject(goldpan)
-    TriggerServerEvent('mms-goldpfanne:server:addreward')
+    if success then
+        TriggerServerEvent('mms-goldpfanne:server:addreward')
+    else
+        VORPcore.NotifyTip(_U('FailedSkillcheck') , 5000)
+    end
     active = false
 end
+
+function DoSkillCheck()
+    -- Keep in mind that these client-side games are only effective against macros and won't protect against other forms of exploits.
+    local randomizer = math.random(Config.MaxDifficulty, Config.MinDifficulty)
+    local skillCheckResult = exports["syn_minigame"]:taskBar(randomizer, 7)
+    return skillCheckResult == 100
+end
+
 
 --- UTILS ---
 

--- a/config.lua
+++ b/config.lua
@@ -2,12 +2,21 @@ Config = {}
 
 Config.defaultlang = "de_lang"
 
+
 ------------------------ Goldpanning Settings -----------------
 
 Config.GoldPanItem = 'goldpan'   --- Goldpan item DB name
 Config.GoldPanTime = 25000  ------ Time for Searching
-Config.RewardChance = 75  ----- 75% Success Rate  
-Config.ToolUsage = 2   ----- Remove Tool Usage Per Golsearch
+Config.RewardChance = 75  ----- 75% Success Rate
+Config.ToolUsage = 2   ----- Remove Tool Usage Per Goldsearch
+
+
+------------------------ SkillCheck Settings ------------------
+
+-- uses syn_minigame which usually comes already with vorp
+Config.DoSkillCheck  = false -- Shall user have to absolve a minigame for skillcheck?
+Config.MaxDifficulty = 3000  -- Lower number is harder.
+Config.MinDifficulty = 6000  -- Lower number is harder.
 
 
 ----------------------- Reward Settings -----------------------

--- a/config.lua
+++ b/config.lua
@@ -10,10 +10,18 @@ Config.GoldPanTime = 25000  ------ Time for Searching
 Config.RewardChance = 75  ----- 75% Success Rate
 Config.ToolUsage = 2   ----- Remove Tool Usage Per Goldsearch
 
+-- Return an item when the player's gold pan reaches 0 durability? 
+Config.ReturnItemOnDepletion = false -- false or item name like "goldpan_broken"
+--[[
+You can run this query to add an basic broken gold pan to your server's database:
+INSERT IGNORE INTO items (`item`, `label`, `limit`, `can_remove`, `type`, `usable`, `desc`) 
+VALUES ('goldpan_broken', 'Gold pan (broken)', 10, 1, 'item_standard', 0, 'A broken gold pan. Perhaps a blacksmith can repair it or at least melt it down.');
+--]]
+
 
 ------------------------ SkillCheck Settings ------------------
 
--- uses syn_minigame which usually comes already with vorp
+-- uses syn_minigame, which usually comes bundled with VORP
 Config.DoSkillCheck  = false -- Shall user have to absolve a minigame for skillcheck?
 Config.MaxDifficulty = 3000  -- Lower number is harder.
 Config.MinDifficulty = 6000  -- Lower number is harder.

--- a/languages/de_lang.lua
+++ b/languages/de_lang.lua
@@ -5,4 +5,5 @@ Locales["de_lang"] = {
     InvFull = 'Du kannst nicht mehr tragen.',
     needNewTool = 'Du brauchst eine neue Goldpfanne.',
     UsageLeft = 'Haltbarkeit: ',
+    FailedSkillcheck = 'Du hast den Goldpfanneninhalt ausversehen verschüttet.',
 }

--- a/languages/de_lang.lua
+++ b/languages/de_lang.lua
@@ -1,8 +1,8 @@
 Locales["de_lang"] = {
-    YouAreGoldpaning = 'Du Schürfst nach Gold',
-    NothingFound = 'Du hast nichts Gefunden',
-    YouFound = 'Du Findest: ',
-    InvFull = 'Du kannst nicht mehr Tragen',
-    needNewTool = 'Du brauchst eine neue Goldpfanne',
+    YouAreGoldpaning = 'Du schürfst nach Gold.',
+    NothingFound = 'Du hast nichts gefunden.',
+    YouFound = 'Du findest: ',
+    InvFull = 'Du kannst nicht mehr tragen.',
+    needNewTool = 'Du brauchst eine neue Goldpfanne.',
     UsageLeft = 'Haltbarkeit: ',
 }

--- a/languages/en_lang.lua
+++ b/languages/en_lang.lua
@@ -5,4 +5,5 @@ Locales["en_lang"] = {
     InvFull = 'You cant carry any more',
     needNewTool = 'You Need a New Goldpan',
     UsageLeft = 'Durability: ',
+    FailedSkillcheck = 'You accidentally spilled the gold pan contents.',
 }

--- a/server/server.lua
+++ b/server/server.lua
@@ -120,6 +120,14 @@ RegisterServerEvent('mms-goldpfanne:server:ToolUsage',function()
         if durabilityValue >= toolUsage then
             exports.vorp_inventory:addItem(src, toolItem, 1, { description = _U('UsageLeft') .. durabilityValue, durability = durabilityValue })
         elseif durabilityValue < toolUsage then
+            if Config.ReturnItemOnDepletion then
+                local CanCarry = exports.vorp_inventory:canCarryItem(src, Config.ReturnItemOnDepletion, 1)
+                if (CanCarry) then
+                    exports.vorp_inventory:addItem(src, Config.ReturnItemOnDepletion, 1, {})
+                else
+                    VORPcore.NotifyTip(src, _U('InvFull'), 5000)
+                end
+            end
             VORPcore.NotifyRightTip(src, _U('needNewTool'), 4000)
         end
     end

--- a/server/server.lua
+++ b/server/server.lua
@@ -82,9 +82,32 @@ RegisterServerEvent('mms-goldpfanne:server:ToolUsage',function()
     local src = source
     local user = VORPcore.getUser(src)
     if not user then return end
+
     local toolItem = Config.GoldPanItem
     local toolUsage = Config.ToolUsage
-    local tool = exports.vorp_inventory:getItem(src, toolItem)
+
+    -- Get all player items from inventory
+    local playerItems = exports.vorp_inventory:getUserInventoryItems(src)
+    if not playerItems then return end
+
+    -- Select tool with the lowest durability
+    local tool
+    local minDurability = 101
+    for _, item in ipairs(playerItems) do
+        if item.name == toolItem then
+            local dura = item.metadata and item.metadata.durability or 100
+            if dura < minDurability then
+                tool = item
+                minDurability = dura
+            end
+        end
+    end
+
+    if not tool then
+        VORPcore.NotifyRightTip(src, _U('needNewTool'), 4000)
+        return
+    end
+
     local toolMeta =  tool['metadata']
 
     if next(toolMeta) == nil then
@@ -95,10 +118,8 @@ RegisterServerEvent('mms-goldpfanne:server:ToolUsage',function()
         exports.vorp_inventory:subItem(src, toolItem, 1, toolMeta)
 
         if durabilityValue >= toolUsage then
-            exports.vorp_inventory:subItem(src, toolItem, 1, toolMeta)
             exports.vorp_inventory:addItem(src, toolItem, 1, { description = _U('UsageLeft') .. durabilityValue, durability = durabilityValue })
         elseif durabilityValue < toolUsage then
-            exports.vorp_inventory:subItem(src, toolItem, 1, toolMeta)
             VORPcore.NotifyRightTip(src, _U('needNewTool'), 4000)
         end
     end


### PR DESCRIPTION
Commit 5496364:
- Moved logic to decide whether player gets a reward from client to server
- Bugfix: Will now correctly choose an item out of the rare item table, when player shall get one
- Bugfix: No more crashes when player shall receive an item out of the rare item table with a table index higher than the normal item table size
- Added: Partial reward if player can’t carry full reward amount

Commit 50877a8:
- Added: Now not using the oldest pan in the players inventory, but the one with the lowest durability. (Prior, getting 5 goldpans and starting to pan would lead to 5 goldpans with 98 dura before reducing the dura of one of them until destruction. Also better in case players trade damaged pans.)

Commit d6d1e8d:
- Added: option to enable a client side minigame like in vorp_mining or vorp_lumberjack to check against macros. Default: disabled.

Commit c16d6e7:
- Added: option to hand the player an replacement item when his gold pan breaks during panning. Default: disabled.


Changes successfully tested on RedM v17120, vorp_core v3.1 and vorp_inventory v4.2.